### PR TITLE
Py mock issue

### DIFF
--- a/pyEpiabm/pyEpiabm/output/_csv_dict_writer.py
+++ b/pyEpiabm/pyEpiabm/output/_csv_dict_writer.py
@@ -25,16 +25,10 @@ class _CsvDictWriter(AbstractReporter):
         """
         super().__init__(folder, clear_folder)
 
-        try:
-            self.f = open(filename, 'w')
-            self.writer = csv.DictWriter(
-                self.f, fieldnames=fieldnames, delimiter=',')
-            self.writer.writeheader()
-        except FileNotFoundError as e:
-            self.f = None
-            self.writer = None
-            # TODO: Log file not found error
-            raise e
+        self.f = open(filename, 'w')
+        self.writer = csv.DictWriter(
+            self.f, fieldnames=fieldnames, delimiter=',')
+        self.writer.writeheader()
 
     def __del__(self):
         """Closes the file when the simulation is finished.

--- a/pyEpiabm/pyEpiabm/output/_csv_writer.py
+++ b/pyEpiabm/pyEpiabm/output/_csv_writer.py
@@ -25,16 +25,10 @@ class _CsvWriter(AbstractReporter):
         """
         super().__init__(folder, clear_folder)
 
-        try:
-            self.f = open(filename, 'w')
-            self.writer = csv.writer(
-                self.f, delimiter=',')
-            self.writer.writerow(fieldnames)
-        except FileNotFoundError as e:
-            self.f = None
-            self.writer = None
-            # TODO: Log file not found error
-            raise e
+        self.f = open(filename, 'w')
+        self.writer = csv.writer(
+            self.f, delimiter=',')
+        self.writer.writerow(fieldnames)
 
     def __del__(self):
         """Closes the file when the simulation is finished.

--- a/pyEpiabm/pyEpiabm/tests/test_output/test_csv_dict_writer.py
+++ b/pyEpiabm/pyEpiabm/tests/test_output/test_csv_dict_writer.py
@@ -8,7 +8,8 @@ class TestCsvDictWriter(unittest.TestCase):
     """Test the methods of the '_CsvDictWriter' class.
     """
 
-    def test_init(self):
+    @patch('os.makedirs')
+    def test_init(self, mock_mkdir):
         """Test the destructor method of the _CsvDictWriter class.
         """
         mo = mock_open()
@@ -19,20 +20,22 @@ class TestCsvDictWriter(unittest.TestCase):
             del(m)
         mo.assert_called_once_with('mock_filename', 'w')
         mo().write.assert_called_once_with('Cat1,Cat2,Cat3\r\n')
+        mock_mkdir.assert_called_with('mock_folder')
 
-    def test_file_not_found(self):
-        mock_content = ['1', '2', '3']
-        with self.assertRaises(FileNotFoundError):
-            test_writer = pe.output._CsvDictWriter('mock_folder',
-                                                   'mocked_folder/test_file',
-                                                   mock_content)
-            self.assertIsNone(test_writer.f)
-            self.assertIsNone(test_writer.writer)
-        self.assertRaises(FileNotFoundError, pe.output._CsvDictWriter,
-                          'mock_folder', 'mocked_folder/test_file',
-                          mock_content)
+    # def test_file_not_found(self):
+    #     mock_content = ['1', '2', '3']
+    #     with self.assertRaises(FileNotFoundError):
+    #         test_writer = pe.output._CsvDictWriter('mock_folder',
+    #                                                'mocked_folder/test_file',
+    #                                                mock_content)
+    #         self.assertIsNone(test_writer.f)
+    #         self.assertIsNone(test_writer.writer)
+    #     self.assertRaises(FileNotFoundError, pe.output._CsvDictWriter,
+    #                       'mock_folder', 'mocked_folder/test_file',
+    #                       mock_content)
 
-    def test_write(self):
+    @patch('os.makedirs')
+    def test_write(self, mock_mkdir):
         """Test the write method of the _CsvDictWriter class.
         """
         mo = mock_open()
@@ -45,7 +48,8 @@ class TestCsvDictWriter(unittest.TestCase):
         mo().write.assert_has_calls([call('Cat1,Cat2,Cat3\r\n'),
                                     call('a,b,c\r\n')])
 
-    def test_del(self):
+    @patch('os.makedirs')
+    def test_del(self, mock_mkdir):
         """Test the destructor method of the _CsvDictWriter class.
         """
         fake_file = MagicMock()

--- a/pyEpiabm/pyEpiabm/tests/test_output/test_csv_dict_writer.py
+++ b/pyEpiabm/pyEpiabm/tests/test_output/test_csv_dict_writer.py
@@ -22,18 +22,6 @@ class TestCsvDictWriter(unittest.TestCase):
         mo().write.assert_called_once_with('Cat1,Cat2,Cat3\r\n')
         mock_mkdir.assert_called_with('mock_folder')
 
-    # def test_file_not_found(self):
-    #     mock_content = ['1', '2', '3']
-    #     with self.assertRaises(FileNotFoundError):
-    #         test_writer = pe.output._CsvDictWriter('mock_folder',
-    #                                                'mocked_folder/test_file',
-    #                                                mock_content)
-    #         self.assertIsNone(test_writer.f)
-    #         self.assertIsNone(test_writer.writer)
-    #     self.assertRaises(FileNotFoundError, pe.output._CsvDictWriter,
-    #                       'mock_folder', 'mocked_folder/test_file',
-    #                       mock_content)
-
     @patch('os.makedirs')
     def test_write(self, mock_mkdir):
         """Test the write method of the _CsvDictWriter class.

--- a/pyEpiabm/pyEpiabm/tests/test_output/test_csv_writer.py
+++ b/pyEpiabm/pyEpiabm/tests/test_output/test_csv_writer.py
@@ -8,7 +8,8 @@ class TestCsvWriter(unittest.TestCase):
     """Test the methods of the '_CsvWriter' class.
     """
 
-    def test_init(self):
+    @patch('os.makedirs')
+    def test_init(self, mock_mkdir):
         """Test the constructor method of the _CsvWriter class.
         """
         mo = mock_open()
@@ -19,19 +20,22 @@ class TestCsvWriter(unittest.TestCase):
             del(m)
         mo.assert_called_once_with('mock_filename', 'w')
         mo().write.assert_called_once_with('1,2,3\r\n')
+        mock_mkdir.assert_called_with('mock_folder')
 
-    def test_file_not_found(self):
-        mock_content = ['1', '2', '3']
-        with self.assertRaises(FileNotFoundError):
-            test_writer = pe.output._CsvWriter('mock_folder',
-                                               'mocked_folder/test_file',
-                                               mock_content)
-            self.assertIsNone(test_writer.f)
-            self.assertIsNone(test_writer.writer)
-        self.assertRaises(FileNotFoundError, pe.output._CsvWriter, 'folder',
-                          'mocked_folder/test_file', mock_content)
+    # #@patch('os.makedirs')
+    # def test_file_not_found(self):
+    #     mock_content = ['1', '2', '3']
+    #     with self.assertRaises(FileNotFoundError):
+    #         test_writer = pe.output._CsvWriter('mock_folder',
+    #                                            'mocked_folder/test_file',
+    #                                            mock_content)
+    #         self.assertIsNone(test_writer.f)
+    #         self.assertIsNone(test_writer.writer)
+    #     self.assertRaises(FileNotFoundError, pe.output._CsvWriter, 'folder',
+    #                       'mocked_folder/test_file', mock_content)
 
-    def test_write(self):
+    @patch('os.makedirs')
+    def test_write(self, mock_mkdir):
         """Test the write method of the _CsvWriter class.
         """
         mo = mock_open()
@@ -43,7 +47,8 @@ class TestCsvWriter(unittest.TestCase):
             m.write(new_content)
         mo().write.assert_has_calls([call('1,2,3\r\n'), call('a,b,c\r\n')])
 
-    def test_del(self):
+    @patch('os.makedirs')
+    def test_del(self, mock_mkdir):
         """Test the destructor method of the _CsvWriter class.
         """
         fake_file = MagicMock()

--- a/pyEpiabm/pyEpiabm/tests/test_output/test_csv_writer.py
+++ b/pyEpiabm/pyEpiabm/tests/test_output/test_csv_writer.py
@@ -22,18 +22,6 @@ class TestCsvWriter(unittest.TestCase):
         mo().write.assert_called_once_with('1,2,3\r\n')
         mock_mkdir.assert_called_with('mock_folder')
 
-    # #@patch('os.makedirs')
-    # def test_file_not_found(self):
-    #     mock_content = ['1', '2', '3']
-    #     with self.assertRaises(FileNotFoundError):
-    #         test_writer = pe.output._CsvWriter('mock_folder',
-    #                                            'mocked_folder/test_file',
-    #                                            mock_content)
-    #         self.assertIsNone(test_writer.f)
-    #         self.assertIsNone(test_writer.writer)
-    #     self.assertRaises(FileNotFoundError, pe.output._CsvWriter, 'folder',
-    #                       'mocked_folder/test_file', mock_content)
-
     @patch('os.makedirs')
     def test_write(self, mock_mkdir):
         """Test the write method of the _CsvWriter class.


### PR DESCRIPTION
I have mocked the `mkdir` call to prevent spurious folder generation in tests.

I have also removed the handling of the file not found error, as I can find a way to trigger this! Previously this handled issues where the folder didn't exist, but this is no longer an issue as the abstract reporter will create one. There will not be issues with the file not existing, as it is opened in write mode, so one will be created if it doesn't exist. If you can think of a case which isn't handled here let me know, but otherwise I think we no longer need it.

Closes #51.