### PR TITLE
Py setup tests

### DIFF
--- a/pyEpiabm/pyEpiabm/tests/test_core/test_cell.py
+++ b/pyEpiabm/pyEpiabm/tests/test_core/test_cell.py
@@ -8,9 +8,8 @@ from pyEpiabm.property.infection_status import InfectionStatus
 class TestCell(unittest.TestCase):
     """Test the 'Cell' class.
     """
-    @classmethod
-    def setUp(cls) -> None:
-        cls.cell = pe.Cell()
+    def setUp(self) -> None:
+        self.cell = pe.Cell()
 
     def test__init__(self):
         self.assertEqual(self.cell.location[0], 0)

--- a/pyEpiabm/pyEpiabm/tests/test_core/test_cell.py
+++ b/pyEpiabm/pyEpiabm/tests/test_core/test_cell.py
@@ -9,7 +9,7 @@ class TestCell(unittest.TestCase):
     """Test the 'Cell' class.
     """
     @classmethod
-    def setUpClass(cls) -> None:
+    def setUp(cls) -> None:
         cls.cell = pe.Cell()
 
     def test__init__(self):
@@ -36,31 +36,27 @@ class TestCell(unittest.TestCase):
         self.assertRaises(ValueError, pe.Cell, ('1', 1))
 
     def test_set_id(self):
-        id_cell = pe.Cell()
-        self.assertEqual(id_cell.id, hash(id_cell))
-        id_cell.set_id(2.0)
-        self.assertEqual(id_cell.id, 2.0)
+        self.assertEqual(self.cell.id, hash(self.cell))
+        self.cell.set_id(2.0)
+        self.assertEqual(self.cell.id, 2.0)
 
     def test_add_microcells(self, n=4):
-        cell = pe.Cell()
-        self.assertEqual(len(cell.microcells), 0)
-        cell.add_microcells(n)
-        self.assertEqual(len(cell.microcells), n)
+        self.assertEqual(len(self.cell.microcells), 0)
+        self.cell.add_microcells(n)
+        self.assertEqual(len(self.cell.microcells), n)
 
     def test_number_infectious(self):
-        cell = pe.Cell()
-        cell.add_microcells(1)
-        cell.microcells[0].add_people(1)
-        person = cell.microcells[0].persons[0]
-        self.assertEqual(cell.number_infectious(), 0)
+        self.cell.add_microcells(1)
+        self.cell.microcells[0].add_people(1)
+        person = self.cell.microcells[0].persons[0]
+        self.assertEqual(self.cell.number_infectious(), 0)
         person.update_status(InfectionStatus.InfectMild)
-        self.assertEqual(cell.number_infectious(), 1)
+        self.assertEqual(self.cell.number_infectious(), 1)
 
     def test_set_loc(self):
-        cell = pe.Cell()
-        self.assertEqual(cell.location, (0, 0))
-        cell.set_location((3.0, 2.0))
-        self.assertEqual(cell.location, (3.0, 2.0))
+        self.assertEqual(self.cell.location, (0, 0))
+        self.cell.set_location((3.0, 2.0))
+        self.assertEqual(self.cell.location, (3.0, 2.0))
 
 
 if __name__ == '__main__':

--- a/pyEpiabm/pyEpiabm/tests/test_core/test_microcell.py
+++ b/pyEpiabm/pyEpiabm/tests/test_core/test_microcell.py
@@ -7,7 +7,7 @@ class TestMicrocell(unittest.TestCase):
     """Test the 'Microcell' class.
     """
     @classmethod
-    def setUpClass(cls) -> None:
+    def setUp(cls) -> None:
         cls.cell = pe.Cell()
         cls.microcell = pe.Microcell(cls.cell)
 
@@ -21,36 +21,32 @@ class TestMicrocell(unittest.TestCase):
                          "Microcell with 0 people.")
 
     def test_set_id(self):
-        id_mcell = pe.Microcell(self.cell)
-        self.assertEqual(id_mcell.id, hash(id_mcell))
-        id_mcell.set_id(2.0)
-        self.assertEqual(id_mcell.id, 2.0)
+        self.assertEqual(self.microcell.id, hash(self.microcell))
+        self.microcell.set_id(2.0)
+        self.assertEqual(self.microcell.id, 2.0)
 
     def test_add_people(self, n=4):
-        cell = pe.Cell()
-        microcell = pe.Microcell(cell)
-        self.assertEqual(len(microcell.persons), 0)
-        microcell.add_people(n)
-        self.assertEqual(len(microcell.persons), n)
-        microcell.add_people(n + 1, pe.property.InfectionStatus.InfectASympt)
-        self.assertEqual(len(microcell.persons), 2 * n + 1)
-        self.assertEqual(cell.number_infectious(), n + 1)
+        self.assertEqual(len(self.microcell.persons), 0)
+        self.microcell.add_people(n)
+        self.assertEqual(len(self.microcell.persons), n)
+        self.microcell.add_people(n + 1,
+                                  pe.property.InfectionStatus.InfectASympt)
+        self.assertEqual(len(self.microcell.persons), 2 * n + 1)
+        self.assertEqual(self.cell.number_infectious(), n + 1)
 
     def test_add_place(self, n=3):
-        microcell = pe.Microcell(self.cell)
-        self.assertEqual(len(microcell.places), 0)
-        microcell.add_place(n, (1.0, 1.0), pe.property.PlaceType.Hotel)
-        self.assertEqual(len(microcell.places), n)
+        self.assertEqual(len(self.microcell.places), 0)
+        self.microcell.add_place(n, (1.0, 1.0), pe.property.PlaceType.Hotel)
+        self.assertEqual(len(self.microcell.places), n)
 
-    def test_setup(self):
-        cell = pe.Cell()
-        cell.add_microcells(5)
+    def test_setup(self, n=5):
+        self.assertEqual(len(self.cell.microcells), 0)
+        self.cell.add_microcells(n)
+        self.assertEqual(len(self.cell.microcells), n)
 
     def test_report(self):
-        cell = pe.Cell()
-        mcell = pe.Microcell(cell)
-        mcell.add_people(5)
-        mcell.notify_person_status_change(
+        self.microcell.add_people(5)
+        self.microcell.notify_person_status_change(
             pe.property.InfectionStatus.Susceptible,
             pe.property.InfectionStatus.Recovered)
 

--- a/pyEpiabm/pyEpiabm/tests/test_core/test_microcell.py
+++ b/pyEpiabm/pyEpiabm/tests/test_core/test_microcell.py
@@ -6,10 +6,9 @@ import pyEpiabm as pe
 class TestMicrocell(unittest.TestCase):
     """Test the 'Microcell' class.
     """
-    @classmethod
-    def setUp(cls) -> None:
-        cls.cell = pe.Cell()
-        cls.microcell = pe.Microcell(cls.cell)
+    def setUp(self) -> None:
+        self.cell = pe.Cell()
+        self.microcell = pe.Microcell(self.cell)
 
     def test__init__(self):
         self.assertEqual(self.microcell.persons, [])

--- a/pyEpiabm/pyEpiabm/tests/test_core/test_person.py
+++ b/pyEpiabm/pyEpiabm/tests/test_core/test_person.py
@@ -7,7 +7,7 @@ class TestPerson(unittest.TestCase):
     """Test the 'Person' class.
     """
     @classmethod
-    def setUpClass(cls) -> None:
+    def setUp(cls) -> None:
         cls.cell = pe.Cell()
         cls.cell.add_microcells(1)
         cls.microcell = cls.cell.microcells[0]

--- a/pyEpiabm/pyEpiabm/tests/test_core/test_person.py
+++ b/pyEpiabm/pyEpiabm/tests/test_core/test_person.py
@@ -6,13 +6,12 @@ import pyEpiabm as pe
 class TestPerson(unittest.TestCase):
     """Test the 'Person' class.
     """
-    @classmethod
-    def setUp(cls) -> None:
-        cls.cell = pe.Cell()
-        cls.cell.add_microcells(1)
-        cls.microcell = cls.cell.microcells[0]
-        cls.microcell.add_people(1)
-        cls.person = cls.microcell.persons[0]
+    def setUp(self) -> None:
+        self.cell = pe.Cell()
+        self.cell.add_microcells(1)
+        self.microcell = self.cell.microcells[0]
+        self.microcell.add_people(1)
+        self.person = self.microcell.persons[0]
 
     def test__init__(self):
         self.assertEqual(self.person.age, 0)

--- a/pyEpiabm/pyEpiabm/tests/test_routine/test_file_population_config.py
+++ b/pyEpiabm/pyEpiabm/tests/test_routine/test_file_population_config.py
@@ -14,9 +14,9 @@ class TestPopConfig(unittest.TestCase):
 
     def setUp(self) -> None:
         self.input = {'cell': [1.0, 2.0], 'microcell': [1.0, 1.0],
-                     'location_x': [0.0, 1.0], 'location_y': [0.0, 1.0],
-                     'household_number': [1, 1],
-                     'Susceptible': [8, 9], 'InfectMild': [2, 3]}
+                      'location_x': [0.0, 1.0], 'location_y': [0.0, 1.0],
+                      'household_number': [1, 1],
+                      'Susceptible': [8, 9], 'InfectMild': [2, 3]}
         self.df = pd.DataFrame(self.input)
 
     @patch('logging.exception')

--- a/pyEpiabm/pyEpiabm/tests/test_routine/test_file_population_config.py
+++ b/pyEpiabm/pyEpiabm/tests/test_routine/test_file_population_config.py
@@ -12,13 +12,12 @@ class TestPopConfig(unittest.TestCase):
     """Test the 'ToyPopConfig' class.
     """
 
-    @classmethod
-    def setUp(cls) -> None:
-        cls.input = {'cell': [1.0, 2.0], 'microcell': [1.0, 1.0],
+    def setUp(self) -> None:
+        self.input = {'cell': [1.0, 2.0], 'microcell': [1.0, 1.0],
                      'location_x': [0.0, 1.0], 'location_y': [0.0, 1.0],
                      'household_number': [1, 1],
                      'Susceptible': [8, 9], 'InfectMild': [2, 3]}
-        cls.df = pd.DataFrame(cls.input)
+        self.df = pd.DataFrame(self.input)
 
     @patch('logging.exception')
     def test_make_pop_no_file(self, mock_log):

--- a/pyEpiabm/pyEpiabm/tests/test_sweep/test_host_progression_sweep.py
+++ b/pyEpiabm/pyEpiabm/tests/test_sweep/test_host_progression_sweep.py
@@ -10,7 +10,7 @@ class TestHostProgressionSweep(unittest.TestCase):
     """Tests the 'HostProgressionSweep' class.
     """
     @classmethod
-    def setUpClass(cls) -> None:
+    def setUp(cls) -> None:
         """Sets up a population we can use throughout the test.
         2 people are located in one microcell.
         """

--- a/pyEpiabm/pyEpiabm/tests/test_sweep/test_host_progression_sweep.py
+++ b/pyEpiabm/pyEpiabm/tests/test_sweep/test_host_progression_sweep.py
@@ -9,18 +9,17 @@ from pyEpiabm.property.infection_status import InfectionStatus
 class TestHostProgressionSweep(unittest.TestCase):
     """Tests the 'HostProgressionSweep' class.
     """
-    @classmethod
-    def setUp(cls) -> None:
+    def setUp(self) -> None:
         """Sets up a population we can use throughout the test.
         2 people are located in one microcell.
         """
-        cls.test_population = pe.Population()
-        cls.test_population.add_cells(1)
-        cls.test_population.cells[0].add_microcells(1)
-        cls.test_population.cells[0].microcells[0].add_people(3)
-        cls.person1 = cls.test_population.cells[0].microcells[0].persons[0]
-        cls.person2 = cls.test_population.cells[0].microcells[0].persons[1]
-        cls.person3 = cls.test_population.cells[0].microcells[0].persons[2]
+        self.test_population = pe.Population()
+        self.test_population.add_cells(1)
+        self.test_population.cells[0].add_microcells(1)
+        self.test_population.cells[0].microcells[0].add_people(3)
+        self.person1 = self.test_population.cells[0].microcells[0].persons[0]
+        self.person2 = self.test_population.cells[0].microcells[0].persons[1]
+        self.person3 = self.test_population.cells[0].microcells[0].persons[2]
 
     def test_construct(self):
         """Tests that the host progression sweep initialises correctly.

--- a/pyEpiabm/pyEpiabm/tests/test_sweep/test_queue_sweep.py
+++ b/pyEpiabm/pyEpiabm/tests/test_sweep/test_queue_sweep.py
@@ -6,22 +6,21 @@ import pyEpiabm as pe
 class TestQueueSweep(unittest.TestCase):
     """Test the 'QueueSweep' class.
     """
-    @classmethod
-    def setUp(cls) -> None:
+    def setUp(self) -> None:
         """Sets up a population we can use throughout the test.
         2 people are located in one microcell.
         """
-        cls.pop_factory = pe.routine.ToyPopulationFactory()
-        cls.pop_params = {"population_size": 2, "cell_number": 1,
-                          "microcell_number": 1, "household_number": 1}
-        cls.test_population = cls.pop_factory.make_pop(cls.pop_params)
+        self.pop_factory = pe.routine.ToyPopulationFactory()
+        self.pop_params = {"population_size": 2, "cell_number": 1,
+                           "microcell_number": 1, "household_number": 1}
+        self.test_population = self.pop_factory.make_pop(self.pop_params)
 
-        cls.cell = cls.test_population.cells[0]
-        cls.person1 = cls.test_population.cells[0].microcells[0].persons[0]
-        cls.person1.infection_status = pe.property.InfectionStatus.InfectMild
-        cls.person2 = cls.test_population.cells[0].microcells[0].persons[1]
+        self.cell = self.test_population.cells[0]
+        self.person1 = self.test_population.cells[0].microcells[0].persons[0]
+        self.person1.infection_status = pe.property.InfectionStatus.InfectMild
+        self.person2 = self.test_population.cells[0].microcells[0].persons[1]
 
-        cls.time = 1
+        self.time = 1
 
     def test_bind(self):
         """Test population binds correctly.

--- a/pyEpiabm/pyEpiabm/tests/test_sweep/test_queue_sweep.py
+++ b/pyEpiabm/pyEpiabm/tests/test_sweep/test_queue_sweep.py
@@ -7,7 +7,7 @@ class TestQueueSweep(unittest.TestCase):
     """Test the 'QueueSweep' class.
     """
     @classmethod
-    def setUpClass(cls) -> None:
+    def setUp(cls) -> None:
         """Sets up a population we can use throughout the test.
         2 people are located in one microcell.
         """


### PR DESCRIPTION
In response to @rcw5890 's [suggestion](https://github.com/SABS-R3-Epidemiology/epiabm/pull/78#discussion_r819082628), I have implemented this in our other tests to ensure there is no dependence on the order tests are run within each class/file. In some cases this could increase the run time slightly, but in no cases more than 10% and the difference is often negligible. Let me know what you think!