### PR TITLE
Speed-up cell set up

### DIFF
--- a/pyEpiabm/pyEpiabm/routine/file_population_config.py
+++ b/pyEpiabm/pyEpiabm/routine/file_population_config.py
@@ -64,6 +64,8 @@ class FilePopulationFactory:
         # Read file into pandas dataframe
         input = pd.read_csv(input_file)
         loc_given = ("location_x" and "location_y" in input.columns.values)
+        # Sort csv on cell id
+        input = input.sort_values(by=["cell", "microcell"])
 
         # Validate all column names in input
         valid_names = ["cell", "microcell", "location_x",
@@ -78,10 +80,13 @@ class FilePopulationFactory:
         # Initialise sweep to assign new people their next infection status
         host_sweep = HostProgressionSweep()
 
+        # Current cell
+        current_cell = None
         # Iterate through lines (one per microcell)
         for _, line in input.iterrows():
             # Check if cell exists, or create it
-            cell = FilePopulationFactory.find_cell(new_pop, line["cell"])
+            cell = FilePopulationFactory.find_cell(new_pop, line["cell"], current_cell)
+            current_cell = cell
 
             if loc_given:
                 location = (line["location_x"], line["location_y"])
@@ -143,7 +148,7 @@ class FilePopulationFactory:
         return new_pop
 
     @staticmethod
-    def find_cell(population: Population, cell_id: float):
+    def find_cell(population: Population, cell_id: float, current_cell: Cell or None):
         """Returns cell with given ID in population, creates one if
         no cell with that ID exists.
 
@@ -160,9 +165,8 @@ class FilePopulationFactory:
             Cell with given ID in population
 
         """
-        for cell in population.cells:
-            if cell.id == cell_id:
-                return cell
+        if (current_cell is not None) and (current_cell.id == cell_id):
+            return current_cell
         new_cell = Cell()
         population.cells.append(new_cell)
         new_cell.set_id(cell_id)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_file_population_config.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_file_population_config.py
@@ -117,12 +117,12 @@ class TestPopConfig(TestPyEpiabm):
         pop.add_cells(2)
         pop.cells[1].set_id(42)
 
-        target_cell = FilePopulationFactory.find_cell(pop, 42)
+        target_cell = FilePopulationFactory.find_cell(pop, 42, pop.cells[1])
         self.assertEqual(target_cell.id, 42)
         self.assertEqual(hash(target_cell), hash(pop.cells[1]))
         self.assertEqual(len(pop.cells), 2)  # No new cell created
 
-        new_cell = FilePopulationFactory.find_cell(pop, 43)
+        new_cell = FilePopulationFactory.find_cell(pop, 43, pop.cells[1])
         self.assertEqual(new_cell.id, 43)
         self.assertEqual(len(pop.cells), 3)  # New cell created
 


### PR DESCRIPTION
## Summary
When reading in the input file we check for every line if the cell is a new cell or similar to the previous considered cell by looping over the whole population and compare cell IDs. This is time consuming.
Solution: Sort the input file on cells and store the current cell. Compare current cell ID with the cell ID in the new line and make a new cell if they do not match.

## Further work

## Checklist

- [ ] All new functions have docstrings in the correct style
- [ ] I've verified the complete docs build locally without errors
- [ ] I've maintained 100% coverage (please mention any 'no cover' annotations explicitly)
- [ ] I've unit-tested all new methods directly

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the wiki with new parameters/model functionality

## Closing issues

closes #213 
