### PR TITLE
Correct docs issues

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: pyEpiabm/docs/source/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: pyEpiabm/requirements.txt


### PR DESCRIPTION
As of yesterday, ReadTheDocs have enforced the use of a v2 config file, and fail builds without one ([details](https://blog.readthedocs.com/migrate-configuration-v2/)):

> We are announcing a new requirement for all builds to use our configuration file version 2. This announcement deprecates builds without a configuration file, as well as version 1 of our configuration file.

> Read the Docs will start requiring a .readthedocs.yaml configuration file for all projects in order to build documentation successfully. We will stop supporting builds without explicit configuration, because this creates implicit dependencies that users aren’t aware of. We plan to start failing builds not using configuration file version 2 on September 25, 2023.

This config file replaces the settings I implemented on their website. However, I am unable to test whether it actually resolves the issue, as ReadTheDocs only read from the main branch (and I would have to change this in the config file itself!). So am slightly relying on faith to get this merged (that it won't cause breaking changes elsewhere), and will iterate if this doesn't work first time.

Resolves #223