### PR TITLE
Bugfix - recovered reinfection

### DIFF
--- a/pyEpiabm/pyEpiabm/core/cell.py
+++ b/pyEpiabm/pyEpiabm/core/cell.py
@@ -82,7 +82,8 @@ class Cell:
         self.id = id
 
     def enqueue_person(self, person: Person):
-        """Add person to queue for processing at end of iteration.
+        """Add person to queue for processing at end of iteration, provided
+        they are not already recovered (and so may be infected).
 
         Parameters
         ----------
@@ -143,7 +144,7 @@ class Cell:
 
     def number_infectious(self):
         """Returns the total number of infectious people in each
-        cell, all ages combined.
+         cell, all ages combined.
 
         Returns
         -------

--- a/pyEpiabm/pyEpiabm/core/cell.py
+++ b/pyEpiabm/pyEpiabm/core/cell.py
@@ -90,7 +90,8 @@ class Cell:
             Person to enqueue
 
         """
-        self.person_queue.put(person)
+        if person.infection_status != InfectionStatus.Recovered:
+            self.person_queue.put(person)
 
     def enqueue_PCR_testing(self, person: Person):
         """Add person to PCR testing queue for processing in testing

--- a/pyEpiabm/pyEpiabm/core/person.py
+++ b/pyEpiabm/pyEpiabm/core/person.py
@@ -54,9 +54,6 @@ class Person:
         self.key_worker = False
         self.date_positive = None
         self.is_vaccinated = False
-        self.id = (str(self.microcell.cell.location[0]) + '_' + 
-                   str(self.microcell.cell.location[1]) + '_' + 
-                   str(len(self.microcell.cell.persons)) + '*')
 
         self.set_random_age(age_group)
 

--- a/pyEpiabm/pyEpiabm/core/person.py
+++ b/pyEpiabm/pyEpiabm/core/person.py
@@ -54,6 +54,9 @@ class Person:
         self.key_worker = False
         self.date_positive = None
         self.is_vaccinated = False
+        self.id = (str(self.microcell.cell.location[0]) + '_' + 
+                   str(self.microcell.cell.location[1]) + '_' + 
+                   str(len(self.microcell.cell.persons)) + '*')
 
         self.set_random_age(age_group)
 


### PR DESCRIPTION
Recovered individuals may be reinfected if they are selected as part of a reinfection event. Given these interactions may still occur organically, it feels more natural to allow such interactions, but prevent recovered individuals from being queued. In the commit history, I have also included a person identifier used in debugging - this is only valid for spatial simulations (as it relies on each cell having a unique location) and so is not to be included in main at this point.

Closes https://github.com/SABS-R3-Epidemiology/epiabm/issues/227