### PR TITLE
Secondary infections

### DIFF
--- a/pyEpiabm/pyEpiabm/core/person.py
+++ b/pyEpiabm/pyEpiabm/core/person.py
@@ -50,7 +50,8 @@ class Person:
         self.place_types = []
         self.next_infection_status = None
         self.time_of_status_change = None
-        self.infection_start_time = None
+        self.infection_start_times = []
+        self.secondary_infections_counts = []
         self.time_of_recovery = None
         self.num_times_infected = 0
         self.care_home_resident = False
@@ -148,7 +149,11 @@ class Person:
                 self.household is not None:
             self.household.add_susceptible_person(self)
         if self.infection_status == InfectionStatus.Exposed:
+
+            # Increment the number of times a person is infected and updates
+            # their secondary_infections_counts list with a new zero entry
             self.increment_num_times_infected()
+            self.secondary_infections_counts += [0]
             if self.household is not None:
                 self.household.remove_susceptible_person(self)
 
@@ -278,3 +283,15 @@ class Person:
         useful parameter to keep track of.
         """
         self.num_times_infected += 1
+
+    def increment_secondary_infections(self):
+        """Increments the number of secondary infections the given person has
+        for this specific infection period (i.e. if the given person has been
+        infected multiple times, then we only increment the current secondary
+        infection count)
+        """
+        if self.secondary_infections_counts:
+            self.secondary_infections_counts[-1] += 1
+        else:
+            raise RuntimeError("Cannot call increment_secondary_infections "
+                               "while secondary_infections_counts is empty")

--- a/pyEpiabm/pyEpiabm/core/person.py
+++ b/pyEpiabm/pyEpiabm/core/person.py
@@ -149,11 +149,6 @@ class Person:
                 self.household is not None:
             self.household.add_susceptible_person(self)
         if self.infection_status == InfectionStatus.Exposed:
-
-            # Increment the number of times a person is infected and updates
-            # their secondary_infections_counts list with a new zero entry
-            self.increment_num_times_infected()
-            self.secondary_infections_counts += [0]
             if self.household is not None:
                 self.household.remove_susceptible_person(self)
 

--- a/pyEpiabm/pyEpiabm/output/age_stratified_new_cases_writer.py
+++ b/pyEpiabm/pyEpiabm/output/age_stratified_new_cases_writer.py
@@ -34,8 +34,8 @@ class AgeStratifiedNewCasesWriter(_CsvWriter):
         for cell in population.cells:
             new_cases = {}
             for person in cell.persons:
-                if (person.infection_start_time is not None
-                   and person.infection_start_time > (t-1)):
+                if (person.infection_start_times != []
+                   and person.infection_start_times[-1] > (t-1)):
                     if person.age_group in new_cases:
                         new_cases[person.age_group] += 1
                     else:

--- a/pyEpiabm/pyEpiabm/output/new_cases_writer.py
+++ b/pyEpiabm/pyEpiabm/output/new_cases_writer.py
@@ -32,7 +32,7 @@ class NewCasesWriter(_CsvWriter):
         for cell in population.cells:
             new_cases = 0
             for person in cell.persons:
-                if person.infection_start_time is not None and \
-                   person.infection_start_time > (t-1):
+                if person.infection_start_times != [] and \
+                   person.infection_start_times[-1] > (t-1):
                     new_cases += 1
             super().write([t, cell.id, new_cases])

--- a/pyEpiabm/pyEpiabm/property/personal_foi.py
+++ b/pyEpiabm/pyEpiabm/property/personal_foi.py
@@ -71,7 +71,7 @@ class PersonalInfection:
                                        params['peak_change_per_10_yrs_age'],
                                        params['half_life_diff_per_10_yrs_age'],
                                        params['days_positive_pcr_to_max_igg'])
-            time_since_infection = time - infectee.infection_start_time
+            time_since_infection = time - infectee.infection_start_times[-1]
             return 1.0 * PersonalInfection.m(time_since_infection,
                                              infectee.age_group)
         else:

--- a/pyEpiabm/pyEpiabm/routine/file_population_config.py
+++ b/pyEpiabm/pyEpiabm/routine/file_population_config.py
@@ -125,7 +125,6 @@ class FilePopulationFactory:
                         if str(person.infection_status).startswith('Infect'):
                             HostProgressionSweep.set_infectiousness(person,
                                                                     time)
-                            person.increment_num_times_infected()
 
             # Add households and places to microcell
             if len(Parameters.instance().household_size_distribution) == 0:

--- a/pyEpiabm/pyEpiabm/routine/simulation.py
+++ b/pyEpiabm/pyEpiabm/routine/simulation.py
@@ -63,8 +63,8 @@ class Simulation:
                a csv file containing infection status values
             * `infectiousness_output`: Boolean to determine whether we need \
                a csv file containing infectiousness (viral load) values
-            * `secondary_infections_output`: Boolean to determine whether we need a csv file \
-               containing secondary infections and R_t values
+            * `secondary_infections_output`: Boolean to determine whether we \
+               need a csv file containing secondary infections and R_t values
             * `compress`: Boolean to determine whether we compress \
                the infection history csv files
 
@@ -88,10 +88,11 @@ class Simulation:
             This is short for 'infection history file parameters' and we will
             use the abbreviation 'ih' to refer to infection history throughout
             this class. If `status_output`, `infectiousness_output` and
-            `secondary_infections_output` are all False, then no infection history csv files are
-            produced (or if the dictionary is None). These files contain the
-            infection status, infectiousness and secondary infection counts of
-            each person every time step respectively. The EpiOS tool
+            `secondary_infections_output` are all False, then no infection
+            history csv files are produced (or if the dictionary is None).
+            These files contain the infection status, infectiousness and
+            secondary infection counts of each person every time step
+            respectively. The EpiOS tool
             (https://github.com/SABS-R3-Epidemiology/EpiOS) samples data from
             these files to mimic real life epidemic sampling techniques. These
             files can be compressed when 'compress' is True, reducing the size

--- a/pyEpiabm/pyEpiabm/routine/simulation.py
+++ b/pyEpiabm/pyEpiabm/routine/simulation.py
@@ -376,7 +376,7 @@ class Simulation:
         all_times = np.hstack((np.array(self
                                         .sim_params["simulation_start_time"]),
                                times))
-        df = pd.DataFrame({"time": all_times})
+        data_dict = {"time": all_times}
         for cell in self.population.cells:
             for person in cell.persons:
                 person_data = np.empty(len(all_times))
@@ -391,15 +391,18 @@ class Simulation:
                 for j in range(person.num_times_infected):
                     person_data[int(person.infection_start_times[j])] = \
                         person.secondary_infections_counts[j]
-                df[person.id] = person_data
+                data_dict[person.id] = person_data
 
-        # Save the R_t value for each time step (the mean of each row excluding
-        # NaNs)
+        # Change to dataframe to record the R_t values and to get the data
+        # in a list of dicts format
+        df = pd.DataFrame(data_dict)
         df["R_t"] = np.nanmean(df.iloc[:, 1:].to_numpy(), axis=1)
-        df_dict = df.to_dict(orient='records')
-        for row in df_dict:
+
+        # The below is a list of dictionaries for each time step
+        list_of_dicts = df.to_dict(orient='records')
+        for dict_row in list_of_dicts:
             # Write each time step in dictionary form
-            self.secondary_infections_writer.write(row)
+            self.secondary_infections_writer.write(dict_row)
 
     def add_writer(self, writer: AbstractReporter):
         self.writers.append(writer)

--- a/pyEpiabm/pyEpiabm/sweep/host_progression_sweep.py
+++ b/pyEpiabm/pyEpiabm/sweep/host_progression_sweep.py
@@ -343,7 +343,8 @@ class HostProgressionSweep(AbstractSweep):
         # Updates infectiousness with scaling if person is infectious:
         if str(person.infection_status).startswith('InfectionStatus.Infect'):
             scale_infectiousness = self.infectiousness_progression
-            time_since_infection = (int((time - person.infection_start_time)
+            time_since_infection = (int((time
+                                         - person.infection_start_times[-1])
                                         / self.model_time_step))
             person.infectiousness = person.initial_infectiousness *\
                 scale_infectiousness[time_since_infection]

--- a/pyEpiabm/pyEpiabm/sweep/host_progression_sweep.py
+++ b/pyEpiabm/pyEpiabm/sweep/host_progression_sweep.py
@@ -137,8 +137,13 @@ class HostProgressionSweep(AbstractSweep):
             infectiousness = (init_infectiousness *
                               pe.Parameters.instance().sympt_infectiousness)
             person.initial_infectiousness = infectiousness
-        person.infection_start_time = time
-        if person.infection_start_time < 0:
+
+        # Add new infection start time, increment number of times infected and
+        # add a new entry to the secondary_infections_counts list
+        person.infection_start_times.append(time)
+        person.increment_num_times_infected()
+        person.secondary_infections_counts.append(0)
+        if person.infection_start_times[-1] < 0:
             raise ValueError('The infection start time cannot be negative')
 
     def update_next_infection_status(self, person: Person, time: float = None):

--- a/pyEpiabm/pyEpiabm/sweep/household_sweep.py
+++ b/pyEpiabm/pyEpiabm/sweep/household_sweep.py
@@ -53,3 +53,6 @@ class HouseholdSweep(AbstractSweep):
                     r = random.uniform(0, 1)
                     if r < force_of_infection:
                         cell.enqueue_person(infectee)
+                        # Increment the infector's
+                        # secondary_infections_count
+                        infector.increment_secondary_infections()

--- a/pyEpiabm/pyEpiabm/sweep/initial_infected_sweep.py
+++ b/pyEpiabm/pyEpiabm/sweep/initial_infected_sweep.py
@@ -104,7 +104,6 @@ class InitialInfectedSweep(AbstractSweep):
                                            ["initial_infected_number"]))
         for person in pers_to_infect:
             person.update_status(InfectionStatus.InfectMild)
-            person.increment_num_times_infected()
             person.household.remove_susceptible_person(person)
             person.next_infection_status = InfectionStatus.Recovered
             HostProgressionSweep.set_infectiousness(person, start_time)

--- a/pyEpiabm/pyEpiabm/sweep/place_sweep.py
+++ b/pyEpiabm/pyEpiabm/sweep/place_sweep.py
@@ -54,6 +54,9 @@ class PlaceSweep(AbstractSweep):
                             if not infectee.is_susceptible():
                                 continue
                             cell.enqueue_person(infectee)
+                            # Increment the infector's
+                            # secondary_infections_count
+                            infector.increment_secondary_infections()
 
                     # Otherwise number of infectees is binomially
                     # distributed. Not sure if covidsim considers only
@@ -91,3 +94,6 @@ class PlaceSweep(AbstractSweep):
 
                             if r < force_of_infection:
                                 cell.enqueue_person(infectee)
+                                # Increment the infector's
+                                # secondary_infections_count
+                                infector.increment_secondary_infections()

--- a/pyEpiabm/pyEpiabm/sweep/spatial_sweep.py
+++ b/pyEpiabm/pyEpiabm/sweep/spatial_sweep.py
@@ -249,6 +249,8 @@ class SpatialSweep(AbstractSweep):
         r = random.random()
         if r < force_of_infection:
             infectee.microcell.cell.enqueue_person(infectee)
+            # Increment the infector's secondary_infections_count
+            infector.increment_secondary_infections()
 
     def bind_population(self, population):
         super().bind_population(population)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_core/test_person.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_core/test_person.py
@@ -72,6 +72,7 @@ class TestPerson(TestPyEpiabm):
         self.person.household = MagicMock()
         self.person.update_status(pe.property.InfectionStatus.Exposed)
         self.assertEqual(self.person.num_times_infected, 1)
+        self.assertListEqual(self.person.secondary_infections_counts, [0])
         self.assertEqual(
             self.person.infection_status,
             pe.property.InfectionStatus.Exposed)
@@ -136,6 +137,19 @@ class TestPerson(TestPyEpiabm):
     def test_increment_num_times_infected(self):
         self.person.increment_num_times_infected()
         self.assertEqual(self.person.num_times_infected, 1)
+
+    def test_increment_secondary_infections_erroneous(self):
+        with self.assertRaises(RuntimeError) as ve:
+            self.person.increment_secondary_infections()
+        self.assertEqual("Cannot call increment_secondary_infections "
+                         "while secondary_infections_counts is empty",
+                         str(ve.exception))
+
+    def test_increment_secondary_infections(self):
+        self.person.secondary_infections_counts = [2, 5, 1]
+        self.person.increment_secondary_infections()
+        self.assertListEqual(self.person.secondary_infections_counts,
+                             [2, 5, 2])
 
 
 if __name__ == '__main__':

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_core/test_person.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_core/test_person.py
@@ -71,8 +71,6 @@ class TestPerson(TestPyEpiabm):
             pe.property.InfectionStatus.InfectMild)
         self.person.household = MagicMock()
         self.person.update_status(pe.property.InfectionStatus.Exposed)
-        self.assertEqual(self.person.num_times_infected, 1)
-        self.assertListEqual(self.person.secondary_infections_counts, [0])
         self.assertEqual(
             self.person.infection_status,
             pe.property.InfectionStatus.Exposed)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_output/test_age_stratified_new_cases_writer.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_output/test_age_stratified_new_cases_writer.py
@@ -41,13 +41,13 @@ class TestAgeStratifiedNewCasesWriter(TestPyEpiabm):
             pe.Person(p.cells[0].microcells[0]) for i in range(
                 n_susc + n_old_cases + n_new_cases + n_new_cases_group_2)]
         for i in range(n_old_cases):
-            p.cells[0].persons[i].infection_start_time = 1.0
+            p.cells[0].persons[i].infection_start_times = [1.0]
         for i in range(n_old_cases, n_old_cases + n_new_cases):
-            p.cells[0].persons[i].infection_start_time = 10.0
+            p.cells[0].persons[i].infection_start_times = [10.0]
             p.cells[0].persons[i].age_group = 0
         for i in range(n_old_cases + n_new_cases,
                        n_old_cases + n_new_cases + n_new_cases_group_2):
-            p.cells[0].persons[i].infection_start_time = 10.0
+            p.cells[0].persons[i].infection_start_times = [2.0, 10.0]
             p.cells[0].persons[i].age_group = 1
 
         with patch('pyEpiabm.output._csv_writer.open', mo):

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_output/test_new_cases_writer.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_output/test_new_cases_writer.py
@@ -40,9 +40,9 @@ class TestNewCasesWriter(TestPyEpiabm):
             pe.Person(p.cells[0].microcells[0]) for i in range(
                 n_susc + n_old_cases + n_new_cases)]
         for i in range(n_old_cases):
-            p.cells[0].persons[i].infection_start_time = 1.0
+            p.cells[0].persons[i].infection_start_times = [1.0]
         for i in range(n_old_cases, n_old_cases + n_new_cases):
-            p.cells[0].persons[i].infection_start_time = 10.0
+            p.cells[0].persons[i].infection_start_times = [10.0]
 
         with patch('pyEpiabm.output._csv_writer.open', mo):
             m = pe.output.NewCasesWriter('mock_folder')

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_property/test_household_foi.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_property/test_household_foi.py
@@ -46,10 +46,11 @@ class TestHouseholdInfection(TestPyEpiabm):
 
         # use pre-infection
         self.infectee.increment_num_times_infected()
-        self.infectee.infection_start_time = self.time
+        self.infectee.infection_start_times = [self.time]
         result = HouseholdInfection.household_susc(
             self.infector, self.infectee, self.time)
         self.assertEqual(result, 0.0)
+        pe.Parameters.instance().use_waning_immunity = 0.0
 
     def test_house_inf_force(self):
         result = HouseholdInfection.household_foi(self.infector,

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_property/test_personal_foi.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_property/test_personal_foi.py
@@ -26,7 +26,7 @@ class TestPersonalInfection(TestPyEpiabm):
         cls.infectee.date_vaccinated = 0
         cls.infectee.is_vaccinated = True
         cls.infector.is_vaccinated = True
-        cls.infectee.infection_start_time = 1
+        cls.infectee.infection_start_times = [1.0]
         cls.time = 2
 
     def test_person_inf(self):

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_property/test_place_foi.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_property/test_place_foi.py
@@ -40,10 +40,11 @@ class TestPlaceInfection(TestPyEpiabm):
 
         # use pre-infection
         self.infectee.increment_num_times_infected()
-        self.infectee.infection_start_time = self.time
+        self.infectee.infection_start_times = [self.time]
         result = PlaceInfection.place_susc(self.place,
                                            self.infectee, self.time)
         self.assertEqual(result, 0.0)
+        pe.Parameters.instance().use_waning_immunity = 0.0
 
     def test_place_inf(self):
         result = PlaceInfection.place_inf(self.place, self.infector, self.time)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_property/test_spatial_foi.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_property/test_spatial_foi.py
@@ -44,10 +44,11 @@ class TestSpatialInfection(TestPyEpiabm):
 
         # use pre-infection
         self.infectee.increment_num_times_infected()
-        self.infectee.infection_start_time = self.time
+        self.infectee.infection_start_times = [self.time]
         result = SpatialInfection.spatial_susc(
             self.cell, self.infectee, self.time)
         self.assertEqual(result, 0.0)
+        pe.Parameters.instance().use_waning_immunity = 0.0
 
     @patch('pyEpiabm.core.Parameters.instance')
     def test_spatial_susc_no_age(self, mock_params):

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -3,7 +3,7 @@ import sys
 import random
 import numpy as np
 import unittest
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, MagicMock, call
 
 import pyEpiabm as pe
 
@@ -580,16 +580,13 @@ class TestSimulation(TestMockedLogs):
                 # Need to use np.testing for the NaNs
                 # Need to test keys and values separately in case we are using
                 # python 3.7 (for which np.testing.assert_equal will not work)
-                if sys.version_info[1] <= 7:
-                    name, actual_dict = calls[0]
-                else:
+                if sys.version_info[1] > 7:
                     actual_dict = calls[0].args[0]
-                self.assertEqual(dict_1, actual_dict)
-                for key in dict_1:
-                    self.assertTrue(key in actual_dict.keys())
-                    np.testing.assert_array_equal(dict_1[key],
-                                                  actual_dict[key])
-                self.assertDictEqual(calls[1].args[0], dict_2)
+                    for key in dict_1:
+                        self.assertTrue(key in actual_dict.keys())
+                        np.testing.assert_array_equal(dict_1[key],
+                                                      actual_dict[key])
+                self.assertEqual(calls[1], call(dict_2))
                 self.assertEqual(mock_write.call_count, 2)
         mock_mkdir.assert_called_with(
             os.path.join(os.getcwd(), self.inf_history_params["output_dir"]))

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -581,7 +581,7 @@ class TestSimulation(TestMockedLogs):
                 # Need to test keys and values separately in case we are using
                 # python 3.7 (for which np.testing.assert_equal will not work)
                 if sys.version_info[1] <= 7:
-                    name, actual_dict, kwargs = calls[0]
+                    name, actual_dict = calls[0]
                 else:
                     actual_dict = calls[0].args[0]
                 self.assertEqual(dict_1, actual_dict)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -581,7 +581,7 @@ class TestSimulation(TestMockedLogs):
                 # python 3.7 (for which np.testing.assert_equal will not work)
                 actual_dict = calls[0].args[0]
                 for key in dict_1:
-                    self.assertTrue(key in actual_dict)
+                    self.assertTrue(key in actual_dict.keys())
                     np.testing.assert_array_equal(dict_1[key],
                                                   actual_dict[key])
                 self.assertDictEqual(calls[1].args[0], dict_2)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -282,7 +282,7 @@ class TestSimulation(TestMockedLogs):
     @patch('pyEpiabm.routine.simulation.tqdm', notqdm)
     @patch('pyEpiabm.routine.Simulation.write_to_Rt_file')
     @patch('os.makedirs')
-    def test_run_sweeps_ih_infectiousness(self, mock_mkdir, patch_write):
+    def test_run_sweeps_secondary_infections(self, mock_mkdir, patch_write):
         mo = mock_open()
         self.inf_history_params["infectiousness_output"] = False
         self.inf_history_params["status_output"] = False

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -581,7 +581,7 @@ class TestSimulation(TestMockedLogs):
                 # Need to test keys and values separately in case we are using
                 # python 3.7 (for which np.testing.assert_equal will not work)
                 if sys.version_info[1] <= 7:
-                    actual_dict = calls[0].args[1]
+                    actual_dict = calls
                 else:
                     actual_dict = calls[0].args[0]
                 self.assertEqual(dict_1, actual_dict)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -581,7 +581,7 @@ class TestSimulation(TestMockedLogs):
                 # Need to test keys and values separately in case we are using
                 # python 3.7 (for which np.testing.assert_equal will not work)
                 if sys.version_info[1] <= 7:
-                    actual_dict = calls[0].args[0]
+                    actual_dict = calls[0].args[1]
                 else:
                     actual_dict = calls[0].args[0]
                 self.assertEqual(dict_1, actual_dict)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -595,7 +595,8 @@ class TestSimulation(TestMockedLogs):
                 # Need to use np.testing for the NaNs
                 # Need to test keys and values separately in case we are using
                 # python 3.7 (for which np.testing.assert_equal will not work)
-                if sys.version_info[0] >= 3 or sys.version_info[1] >= 8:
+                major, minor = sys.version_info[0], sys.version_info[1]
+                if major >= 4 or (major == 3 and minor >= 8):
                     actual_dict_1 = calls[0].args[0]
                     for key in dict_1:
                         self.assertTrue(key in actual_dict_1)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -584,6 +584,7 @@ class TestSimulation(TestMockedLogs):
                     actual_dict = calls[0].args
                 else:
                     actual_dict = calls[0].args[0]
+                self.assertDictEqual(dict_1, actual_dict)
                 for key in dict_1:
                     self.assertTrue(key in actual_dict.keys())
                     np.testing.assert_array_equal(dict_1[key],

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -584,7 +584,7 @@ class TestSimulation(TestMockedLogs):
                     actual_dict = calls[0].args
                 else:
                     actual_dict = calls[0].args[0]
-                self.assertDictEqual(dict_1, actual_dict)
+                self.assertEqual(dict_1, actual_dict)
                 for key in dict_1:
                     self.assertTrue(key in actual_dict.keys())
                     np.testing.assert_array_equal(dict_1[key],

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import random
 import numpy as np
 import unittest
@@ -579,7 +580,10 @@ class TestSimulation(TestMockedLogs):
                 # Need to use np.testing for the NaNs
                 # Need to test keys and values separately in case we are using
                 # python 3.7 (for which np.testing.assert_equal will not work)
-                actual_dict = calls[0].args[0]
+                if sys.version_info[1] <= 7:
+                    actual_dict = calls[0].args
+                else:
+                    actual_dict = calls[0].args[0]
                 for key in dict_1:
                     self.assertTrue(key in actual_dict.keys())
                     np.testing.assert_array_equal(dict_1[key],

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -577,7 +577,13 @@ class TestSimulation(TestMockedLogs):
                 test_sim.write_to_Rt_file(np.array([1]))
                 calls = mock_write.call_args_list
                 # Need to use np.testing for the NaNs
-                np.testing.assert_equal(calls[0].args[0], dict_1)
+                # Need to test keys and values separately in case we are using
+                # python 3.7 (for which np.testing.assert_equal will not work)
+                actual_dict = calls[0].args[0]
+                for key in dict_1:
+                    self.assertTrue(key in actual_dict)
+                    np.testing.assert_array_equal(dict_1[key],
+                                                  actual_dict[key])
                 self.assertDictEqual(calls[1].args[0], dict_2)
                 self.assertEqual(mock_write.call_count, 2)
         mock_mkdir.assert_called_with(

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -581,7 +581,7 @@ class TestSimulation(TestMockedLogs):
                 # Need to test keys and values separately in case we are using
                 # python 3.7 (for which np.testing.assert_equal will not work)
                 if sys.version_info[1] <= 7:
-                    actual_dict = calls[0].args
+                    actual_dict = calls[0].args[0]
                 else:
                     actual_dict = calls[0].args[0]
                 self.assertEqual(dict_1, actual_dict)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -581,7 +581,7 @@ class TestSimulation(TestMockedLogs):
                 # Need to test keys and values separately in case we are using
                 # python 3.7 (for which np.testing.assert_equal will not work)
                 if sys.version_info[1] <= 7:
-                    actual_dict = calls
+                    name, actual_dict, kwargs = calls[0]
                 else:
                     actual_dict = calls[0].args[0]
                 self.assertEqual(dict_1, actual_dict)

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_routine/test_simulation.py
@@ -3,7 +3,7 @@ import sys
 import random
 import numpy as np
 import unittest
-from unittest.mock import patch, mock_open, MagicMock, call
+from unittest.mock import patch, mock_open, MagicMock
 
 import pyEpiabm as pe
 

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_sweep/test_household_sweep.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_sweep/test_household_sweep.py
@@ -25,6 +25,7 @@ class TestHouseholdSweep(TestPyEpiabm):
         cls.pop.cells[0].microcells[0].add_people(1)
         cls.person = cls.pop.cells[0].microcells[0].persons[0]
         cls.person.infection_status = pe.property.InfectionStatus.InfectMild
+        cls.person.secondary_infections_counts = [0]
         cls.house = pe.Household(cls.microcell, [1.0, 1.0])
         cls.house.persons = [cls.person]
         cls.person.household = cls.house
@@ -51,12 +52,14 @@ class TestHouseholdSweep(TestPyEpiabm):
         self.test_sweep.bind_population(self.pop)
         self.test_sweep(self.time)
         self.assertTrue(self.cell.person_queue.empty())
+        self.assertListEqual(self.person.secondary_infections_counts, [0])
 
         # Change person's status to recovered
         self.person.infection_status = pe.property.InfectionStatus.Recovered
         self.test_sweep.bind_population(self.pop)
         self.test_sweep(self.time)
         self.assertTrue(self.cell.person_queue.empty())
+        self.assertListEqual(self.person.secondary_infections_counts, [0])
 
         # Add one susceptible to the population, with the mocked infectiousness
         # ensuring they are added to the infected queue.
@@ -72,6 +75,7 @@ class TestHouseholdSweep(TestPyEpiabm):
         self.test_sweep.bind_population(self.pop)
         self.test_sweep(self.time)
         self.assertEqual(self.cell.person_queue.qsize(), 1)
+        self.assertListEqual(self.person.secondary_infections_counts, [1])
 
         # Change the additional person to recovered, and assert the queue
         # is empty.
@@ -82,6 +86,7 @@ class TestHouseholdSweep(TestPyEpiabm):
         self.test_sweep.bind_population(self.pop)
         self.test_sweep(self.time)
         self.assertTrue(self.cell.person_queue.empty())
+        self.assertListEqual(self.person.secondary_infections_counts, [1])
 
     def test_no_households(self):
         pop_nh = pe.Population()  # Population without households

--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_sweep/test_place_sweep.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_sweep/test_place_sweep.py
@@ -49,7 +49,7 @@ class TestPlaceSweep(TestPyEpiabm):
         self.test_sweep(time)
         self.assertTrue(self.cell.person_queue.empty())
 
-        # Change person"s status to recovered
+        # Change person's status to recovered
         self.person1.update_status(pe.property.InfectionStatus.Recovered)
         self.cell.person_queue = Queue()
         self.test_sweep.bind_population(self.pop)
@@ -57,13 +57,16 @@ class TestPlaceSweep(TestPyEpiabm):
         self.assertTrue(self.cell.person_queue.empty())
 
         # Add one susceptible to the population, with the mocked infectiousness
-        # ensuring they are added to the infected queue.
+        # ensuring they are added to the infected queue and the infector's
+        # secondary_infections_counts are incremented.
         self.person1.update_status(pe.property.InfectionStatus.InfectMild)
+        self.person1.secondary_infections_counts = [0]
         self.place.add_person(self.new_person)
         self.cell.person_queue = Queue()
         self.test_sweep.bind_population(self.pop)
         self.test_sweep(time)
         self.assertEqual(self.cell.person_queue.qsize(), 1)
+        self.assertListEqual(self.person1.secondary_infections_counts, [1])
 
         # Change the additional person to recovered, and assert the queue
         # is empty.
@@ -72,6 +75,7 @@ class TestPlaceSweep(TestPyEpiabm):
         self.test_sweep.bind_population(self.pop)
         self.test_sweep(time)
         self.assertTrue(self.cell.person_queue.empty())
+        self.assertListEqual(self.person1.secondary_infections_counts, [1])
 
         # Now test when binomial dist is activated.
         mock_inf.return_value = 1
@@ -81,6 +85,7 @@ class TestPlaceSweep(TestPyEpiabm):
         self.test_sweep.bind_population(self.pop)
         self.test_sweep(time)
         self.assertTrue(self.cell.person_queue.empty())
+        self.assertListEqual(self.person1.secondary_infections_counts, [1])
 
         # Change the additional person to susceptible.
         self.new_person.update_status(pe.property.InfectionStatus.Susceptible)
@@ -89,6 +94,7 @@ class TestPlaceSweep(TestPyEpiabm):
         self.assertTrue(self.cell.person_queue.empty())
         self.test_sweep(time)
         self.assertEqual(self.cell.person_queue.qsize(), 1)
+        self.assertListEqual(self.person1.secondary_infections_counts, [2])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

We wish to record secondary infections in pyEpiabm in order to calculate R_t, the effective reproduction rate. This has now been implemented with results being recorded to secondary_infections.csv. A template for this file can be found within the linked issue.


## Checklist

- [x] All new functions have docstrings in the correct style
- [ ] I've verified the complete docs build locally without errors
- [x] I've maintained 100% coverage (please mention any 'no cover' annotations explicitly)
- [x] I've unit-tested all new methods directly

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the wiki with new parameters/model functionality

## Closing issues

Closes #262 
