### PR TITLE
Added counts.csv file to record the number of people in each age group and cell

### DIFF
--- a/pyEpiabm/pyEpiabm/tests/test_unit/test_sweep/test_initial_demographics_sweep.py
+++ b/pyEpiabm/pyEpiabm/tests/test_unit/test_sweep/test_initial_demographics_sweep.py
@@ -22,18 +22,22 @@ class TestInitialDemographicsSweep(TestPyEpiabm):
         microcell_0_0 = self.test_population.cells[0].microcells[0]
         microcell_0_0.add_household([microcell_0_0.persons[0]])
         person_0_0_0_0 = microcell_0_0.households[0].persons[0]
+        person_0_0_0_0.age_group = 5
         person_0_0_0_0.age = 25
         person_0_0_0_0.key_worker = True
         microcell_1_0 = self.test_population.cells[1].microcells[0]
         microcell_1_0.add_household([microcell_1_0.persons[0],
                                      microcell_1_0.persons[1]])
         person_1_0_0_0 = microcell_1_0.households[0].persons[0]
+        person_1_0_0_0.age_group = 13
         person_1_0_0_0.age = 65
         person_1_0_0_0.care_home_resident = True
         person_1_0_0_1 = microcell_1_0.households[0].persons[1]
+        person_1_0_0_1
         person_1_0_0_1.age = 40
         self.dem_file_params = {"output_dir":
                                 "pyEpiabm/pyEpiabm/tests/test_output/mock"}
+        self.count_titles = ["Cell"] + [f"Age group {i}" for i in range(17)]
 
     @patch('os.makedirs')
     def test_construct_invalid_input(self, mock_mkdir):
@@ -65,6 +69,12 @@ class TestInitialDemographicsSweep(TestPyEpiabm):
 
     @patch('os.makedirs')
     def test_construct(self, mock_mkdir):
+        file_name = os.path.join(os.getcwd(),
+                                 self.dem_file_params["output_dir"],
+                                 "demographics.csv")
+        counts_file_name = os.path.join(os.getcwd(),
+                                        self.dem_file_params["output_dir"],
+                                        "counts.csv")
         mo = mock_open()
         with patch('pyEpiabm.output._csv_dict_writer.open', mo):
             # Now test init using valid input
@@ -72,13 +82,24 @@ class TestInitialDemographicsSweep(TestPyEpiabm):
             dem_sweep.bind_population(self.test_population)
             self.assertEqual(dem_sweep.spatial_output, False)
             self.assertEqual(dem_sweep.age_output, False)
-            file_name = os.path.join(os.getcwd(),
-                                     self.dem_file_params["output_dir"],
-                                     "demographics.csv")
             self.assertEqual(dem_sweep.titles, ["id", "kw_or_chr"])
+            self.assertEqual(dem_sweep.count_titles, ["Cell",
+                                                      "Age group 0"])
             del dem_sweep.writer
-        mo.assert_called_with(file_name, 'w')
+            del dem_sweep.counts_writer
+        mo.assert_has_calls([call(file_name, 'w'),
+                             call(counts_file_name, 'w')],
+                            any_order=True)
 
+    @patch('os.makedirs')
+    def test_construct_age_spatial(self, mock_mkdir):
+        file_name = os.path.join(os.getcwd(),
+                                 self.dem_file_params["output_dir"],
+                                 "demographics.csv")
+        counts_file_name = os.path.join(os.getcwd(),
+                                        self.dem_file_params["output_dir"],
+                                        "counts.csv")
+        mo = mock_open()
         self.dem_file_params["spatial_output"] = True
         self.dem_file_params["age_output"] = True
         with patch('pyEpiabm.output._csv_dict_writer.open', mo):
@@ -87,14 +108,16 @@ class TestInitialDemographicsSweep(TestPyEpiabm):
             dem_sweep.bind_population(self.test_population)
             self.assertEqual(dem_sweep.spatial_output, True)
             self.assertEqual(dem_sweep.age_output, True)
-            file_name = os.path.join(os.getcwd(),
-                                     self.dem_file_params["output_dir"],
-                                     "demographics.csv")
             self.assertEqual(dem_sweep.titles, ["id", "age",
                                                 "location_x", "location_y",
                                                 "kw_or_chr"])
+            self.assertEqual(dem_sweep.count_titles, ["Cell"] +
+                             [f"Age group {i}" for i in range(17)])
             del dem_sweep.writer
-        mo.assert_called_with(file_name, 'w')
+            del dem_sweep.counts_writer
+        mo.assert_has_calls([call(file_name, 'w'),
+                             call(counts_file_name, 'w')],
+                            any_order=True)
 
     @patch('os.makedirs')
     def test_write_to_file_no_age_no_spatial(self, mock_mkdir):
@@ -111,12 +134,19 @@ class TestInitialDemographicsSweep(TestPyEpiabm):
             person_0_0_0_0_data = {"id": "0.0.0.0", "kw_or_chr": 'W'}
             person_1_0_0_0_data = {"id": "1.0.0.0", "kw_or_chr": 'C'}
             person_1_0_0_1_data = {"id": "1.0.0.1", "kw_or_chr": 'X'}
+            cell_0_data = {"Cell": "0", "Age group 0": 1}
+            cell_1_data = {"Cell": "1", "Age group 0": 2}
             with patch.object(dem_sweep.writer, 'write') as mock:
-                dem_sweep()
-                mock.assert_has_calls([call(person_0_0_0_0_data),
-                                       call(person_1_0_0_0_data),
-                                       call(person_1_0_0_1_data)])
-                self.assertEqual(mock.call_count, 3)
+                with patch.object(dem_sweep.counts_writer,
+                                  'write') as mock_count_write:
+                    dem_sweep()
+                    mock.assert_has_calls([call(person_0_0_0_0_data),
+                                           call(person_1_0_0_0_data),
+                                           call(person_1_0_0_1_data)])
+                    self.assertEqual(mock.call_count, 3)
+                    mock_count_write.assert_has_calls([call(cell_0_data),
+                                                       call(cell_1_data)])
+                    self.assertEqual(mock_count_write.call_count, 2)
         mock_mkdir.assert_called_with(os.path.join(os.getcwd(),
                                                    self.dem_file_params[
                                                        "output_dir"]))
@@ -139,12 +169,24 @@ class TestInitialDemographicsSweep(TestPyEpiabm):
                                    "kw_or_chr": 'C'}
             person_1_0_0_1_data = {"id": "1.0.0.1", "age": 40,
                                    "kw_or_chr": 'X'}
+            cell_0_data = {title: 0 for title in self.count_titles}
+            cell_0_data["Cell"] = "0"
+            cell_0_data["Age group 5"] = 1
+            cell_1_data = {title: 0 for title in self.count_titles}
+            cell_1_data["Cell"] = "1"
+            cell_1_data["Age group 13"] = 1
+            cell_1_data["Age group 8"] = 1
             with patch.object(dem_sweep.writer, 'write') as mock:
-                dem_sweep()
-                mock.assert_has_calls([call(person_0_0_0_0_data),
-                                       call(person_1_0_0_0_data),
-                                       call(person_1_0_0_1_data)])
-                self.assertEqual(mock.call_count, 3)
+                with patch.object(dem_sweep.counts_writer,
+                                  'write') as mock_count_write:
+                    dem_sweep()
+                    mock.assert_has_calls([call(person_0_0_0_0_data),
+                                           call(person_1_0_0_0_data),
+                                           call(person_1_0_0_1_data)])
+                    self.assertEqual(mock.call_count, 3)
+                    mock_count_write.assert_has_calls([call(cell_0_data),
+                                                       call(cell_1_data)])
+                    self.assertEqual(mock_count_write.call_count, 2)
         mock_mkdir.assert_called_with(os.path.join(os.getcwd(),
                                                    self.dem_file_params[
                                                        "output_dir"]))


### PR DESCRIPTION
## Summary

In EpiOS, the pre-processing is slowed down by having to calculate the totals of people in each age group and cell. I have
added the counts.csv file to a simulation to record the number of people in each age group and cell separately from the
demographics.csv file.

## Checklist

- [ ] All new functions have docstrings in the correct style
- [ ] I've verified the complete docs build locally without errors
- [ ] I've maintained 100% coverage (please mention any 'no cover' annotations explicitly)
- [ ] I've unit-tested all new methods directly

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the wiki with new parameters/model functionality
